### PR TITLE
Return default cluster when ran on a system that does not support os.uname (Windows)

### DIFF
--- a/audiocraft/utils/cluster.py
+++ b/audiocraft/utils/cluster.py
@@ -27,7 +27,7 @@ class ClusterType(Enum):
 def _guess_cluster_type() -> ClusterType:
     try:
         uname = os.uname()
-    except:
+    except AttributeError:
         return ClusterType.DEFAULT
     
     fqdn = socket.getfqdn()

--- a/audiocraft/utils/cluster.py
+++ b/audiocraft/utils/cluster.py
@@ -25,7 +25,11 @@ class ClusterType(Enum):
 
 
 def _guess_cluster_type() -> ClusterType:
-    uname = os.uname()
+    try:
+        uname = os.uname()
+    except:
+        return ClusterType.DEFAULT
+    
     fqdn = socket.getfqdn()
     if uname.sysname == "Linux" and (uname.release.endswith("-aws") or ".ec2" in fqdn):
         return ClusterType.AWS


### PR DESCRIPTION
## Why?

On Windows, there is no `os.uname`. This makes `_guess_cluster_type` throw an error.

## How?

Catch the AttributeError and return the default cluster in that case.